### PR TITLE
Ticket2400: Added support for ENGIN-X Jaws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 O.*/
-db/
-bin/
-dbd/
-include/
-lib/
-templates/
+/db/
+/bin/
+/dbd/
+/include/
+/lib/
+/templates/
 doc/
 data/
 envPaths

--- a/enginxJawsApp/Db/Makefile
+++ b/enginxJawsApp/Db/Makefile
@@ -1,0 +1,23 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+DB += enginxjawset.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/enginxJawsApp/Db/enginxjawset.substitutions
+++ b/enginxJawsApp/Db/enginxjawset.substitutions
@@ -1,7 +1,7 @@
 
 file enginxjawset.template { 
   pattern 
-    {DIR,           dir_name,		P,       JAWS,			MTR,  			HIGH_GAP_LIMIT, 		LOW_GAP_LIMIT, 		MTR_TO_GAP, 					MTR_FROM_GAP}
-    {"V", 		"Vertical",		"\$(P)", "\$(JAWS)",	"\$(NS_MTR)", 		"25", 					"0.5", 				"-0.0358*A*A+2.0167*A+2.0091", 	"0.0138*A*A+0.4146*A-1.1885"}
-    {"H", 		"Horizontal",	"\$(P)", "\$(JAWS)",	"\$(EW_MTR)", 		"10", 					"0.5",				"0.0434*A*A+0.4519*A+0.8232",  "-0.0776*A*A-1.9001*A+8.9105"}
+    {DIR,           dir_name,		P,       JAWS,			MTR,  		HIGH_GAP_LIMIT, LOW_GAP_LIMIT, 		MTR_TO_GAP_A, 	MTR_TO_GAP_B, 	MTR_TO_GAP_C,			MTR_FRM_GAP_A, 	MTR_FRM_GAP_B, 	MTR_FRM_GAP_C}
+    {"V", 		"Vertical",		"\$(P)", "\$(JAWS)",	"\$(NS_MTR)", 	"25", 			"0.5", 				-0.0358, 		2.0167,			2.0091, 				0.0138,			0.4146,			-1.1885}
+    {"H", 		"Horizontal",	"\$(P)", "\$(JAWS)",	"\$(EW_MTR)", 	"10", 			"0.5",				0.0434,			0.4519,			0.8232,  				-0.0776,		-1.9001,		8.9105}
 }

--- a/enginxJawsApp/Db/enginxjawset.substitutions
+++ b/enginxJawsApp/Db/enginxjawset.substitutions
@@ -2,6 +2,6 @@
 file enginxjawset.template { 
   pattern 
     {DIR,           dir_name,		P,       JAWS,			MTR,  			HIGH_GAP_LIMIT, 		LOW_GAP_LIMIT, 		MTR_TO_GAP, 					MTR_FROM_GAP}
-    {"V", 		"Vertical",		"\$(P)", "\$(JAWS)",	"\$(NS_MTR)", 		"100", 					"0", 				"0.0138*A*A+0.4146*A+1.1885", 	"-0.0358*A*A+2.0167*A-2.0091"}
-    {"H", 		"Horizontal",	"\$(P)", "\$(JAWS)",	"\$(EW_MTR)", 		"100", 					"0",				"-0.0776*A*A+1.9001*A+8.9105",  "0.0434*A*A-0.4519*A+0.8232"}
+    {"V", 		"Vertical",		"\$(P)", "\$(JAWS)",	"\$(NS_MTR)", 		"25", 					"0.5", 				"-0.0358*A*A+2.0167*A+2.0091", 	"0.0138*A*A+0.4146*A-1.1885"}
+    {"H", 		"Horizontal",	"\$(P)", "\$(JAWS)",	"\$(EW_MTR)", 		"10", 					"0.5",				"0.0434*A*A+0.4519*A+0.8232",  "-0.0776*A*A-1.9001*A+8.9105"}
 }

--- a/enginxJawsApp/Db/enginxjawset.substitutions
+++ b/enginxJawsApp/Db/enginxjawset.substitutions
@@ -1,0 +1,7 @@
+
+file enginxjawset.template { 
+  pattern 
+    {DIR,           dir_name,		P,       JAWS,			MTR,  			HIGH_GAP_LIMIT, 		LOW_GAP_LIMIT, 		MTR_TO_GAP, 					MTR_FROM_GAP}
+    {"V", 		"Vertical",		"\$(P)", "\$(JAWS)",	"\$(NS_MTR)", 		"100", 					"0", 				"0.0138*A*A+0.4146*A+1.1885", 	"-0.0358*A*A+2.0167*A-2.0091"}
+    {"H", 		"Horizontal",	"\$(P)", "\$(JAWS)",	"\$(EW_MTR)", 		"100", 					"0",				"-0.0776*A*A+1.9001*A+8.9105",  "0.0434*A*A-0.4519*A+0.8232"}
+}

--- a/enginxJawsApp/Db/enginxjawset.template
+++ b/enginxJawsApp/Db/enginxjawset.template
@@ -35,14 +35,66 @@ record(motor,"$(P)$(JAWS)$(DIR)GAP")
 alias("$(P)$(JAWS)$(DIR)GAP", "$(P)$(JAWS)$(DIR)GAP:SP")
 alias("$(P)$(JAWS)$(DIR)GAP", "$(P)$(JAWS)$(DIR)GAP:SP:RBV")
 
+# The quadratic for calibration is separated out so writing does not affect motor
+record(ao, "$(P)$(JAWS)$(DIR)MFRMGAP:A:SP")
+{
+	field(DESC,"The A coeff to conv gap to steps")
+	field(VAL, "$(MTR_FRM_GAP_A)")
+	field(PREC, "4")
+	info(autosaveFields, "VAL")
+}
+
+record(ao, "$(P)$(JAWS)$(DIR)MFRMGAP:B:SP")
+{
+	field(DESC,"The B coeff to conv gap to steps")
+	field(VAL, "$(MTR_FRM_GAP_B)")
+	field(PREC, "4")
+	info(autosaveFields, "VAL")
+}
+
+record(ao, "$(P)$(JAWS)$(DIR)MFRMGAP:C:SP")
+{
+	field(DESC,"The C coeff to conv gap to steps")
+	field(VAL, "$(MTR_FRM_GAP_C)")
+	field(PREC, "4")
+	info(autosaveFields, "VAL")
+}
+
 # Note that this will be changed by scientists
 record(calcout, "$(P)$(JAWS)$(DIR)MFRMGAP") 
 { 
-	field(DESC,"Convert gap distance to steps") 
-    field(CALC,"$(MTR_FROM_GAP)") 	
+	field(DESC,"Convert gap distance to steps")
+	field(INPB, "$(P)$(JAWS)$(DIR)MFRMGAP:A:SP")
+	field(INPC, "$(P)$(JAWS)$(DIR)MFRMGAP:B:SP")
+	field(INPD, "$(P)$(JAWS)$(DIR)MFRMGAP:C:SP")
+    field(CALC,"B*A*A+C*A+D")
     field(OUT,"$(P)$(MTR).DVAL  PP MS")
-	info(autosaveFields, "CALC")
 	info(INTEREST, "MEDIUM")
+}
+
+# The quadratic for calibration is separated out so writing does not affect motor
+record(ao, "$(P)$(JAWS)$(DIR)MTOGAP:A:SP")
+{
+	field(DESC,"The A coeff to conv steps to gap")
+	field(VAL, "$(MTR_TO_GAP_A)")
+	field(PREC, "4")
+	info(autosaveFields, "VAL")
+}
+
+record(ao, "$(P)$(JAWS)$(DIR)MTOGAP:B:SP")
+{
+	field(DESC,"The B coeff to conv steps to gap")
+	field(VAL, "$(MTR_TO_GAP_B)")
+	field(PREC, "4")
+	info(autosaveFields, "VAL")
+}
+
+record(ao, "$(P)$(JAWS)$(DIR)MTOGAP:C:SP")
+{
+	field(DESC,"The C coeff to conv steps to gap")
+	field(VAL, "$(MTR_TO_GAP_C)")
+	field(PREC, "4")
+	info(autosaveFields, "VAL")
 }
 
 # Note that this will be changed by scientists
@@ -50,7 +102,9 @@ record(calcout,"$(P)$(JAWS)$(DIR)MTOGAP")
 {
     field(DESC,"Convert steps to gap distance")
     field(INPA,"$(P)$(MTR).DRBV  CP MS")
-    field(CALC,"$(MTR_TO_GAP)")
-	info(autosaveFields, "CALC")
+	field(INPB, "$(P)$(JAWS)$(DIR)MTOGAP:A:SP")
+	field(INPC, "$(P)$(JAWS)$(DIR)MTOGAP:B:SP")
+	field(INPD, "$(P)$(JAWS)$(DIR)MTOGAP:C:SP")
+    field(CALC,"B*A*A+C*A+D")
 	info(INTEREST, "MEDIUM")
 }

--- a/enginxJawsApp/Db/enginxjawset.template
+++ b/enginxJawsApp/Db/enginxjawset.template
@@ -6,8 +6,8 @@
 #    MTR - the IOC postfix of the motor that is being used to drive the slits
 #    HIGH_GAP_LIMIT highest gap value that can be set
 #    LOW_GAP_LIMIT lowest gap value that can be set
-#	 MTR_TO_GAP the equation to change the motor reading to a gap
-#	 MTR_FROM_GAP the equation to change the gap to the motor set point
+#	 MTR_TO_GAP the initial equation to change the motor reading to a gap
+#	 MTR_FROM_GAP the initial equation to change the gap to the motor set point
 
 record(motor,"$(P)$(JAWS)$(DIR)GAP") 
 { 
@@ -35,17 +35,22 @@ record(motor,"$(P)$(JAWS)$(DIR)GAP")
 alias("$(P)$(JAWS)$(DIR)GAP", "$(P)$(JAWS)$(DIR)GAP:SP")
 alias("$(P)$(JAWS)$(DIR)GAP", "$(P)$(JAWS)$(DIR)GAP:SP:RBV")
 
-
+# Note that this will be changed by scientists
 record(calcout, "$(P)$(JAWS)$(DIR)MFRMGAP") 
 { 
 	field(DESC,"Convert gap distance to steps") 
     field(CALC,"$(MTR_FROM_GAP)") 	
     field(OUT,"$(P)$(MTR).DVAL  PP MS")
+	info(autosaveFields, "CALC")
+	info(INTEREST, "MEDIUM")
 }
 
+# Note that this will be changed by scientists
 record(calcout,"$(P)$(JAWS)$(DIR)MTOGAP") 
 {
     field(DESC,"Convert steps to gap distance")
     field(INPA,"$(P)$(MTR).DRBV  CP MS")
-    field(CALC,"$(MTR_TO_GAP)") 
+    field(CALC,"$(MTR_TO_GAP)")
+	info(autosaveFields, "CALC")
+	info(INTEREST, "MEDIUM")
 }

--- a/enginxJawsApp/Db/enginxjawset.template
+++ b/enginxJawsApp/Db/enginxjawset.template
@@ -72,7 +72,7 @@ record(calcout, "$(P)$(JAWS)$(DIR)MFRMGAP")
 	info(INTEREST, "MEDIUM")
 }
 
-# The quadratic for calibration is separated out so writing does not affect motor
+# The quadratic for calibration is separated out to match the other record. However, we do want the gap to update when the read coeffs are updated
 record(ao, "$(P)$(JAWS)$(DIR)MTOGAP:A:SP")
 {
 	field(DESC,"The A coeff to conv steps to gap")
@@ -102,9 +102,9 @@ record(calcout,"$(P)$(JAWS)$(DIR)MTOGAP")
 {
     field(DESC,"Convert steps to gap distance")
     field(INPA,"$(P)$(MTR).DRBV  CP MS")
-	field(INPB, "$(P)$(JAWS)$(DIR)MTOGAP:A:SP")
-	field(INPC, "$(P)$(JAWS)$(DIR)MTOGAP:B:SP")
-	field(INPD, "$(P)$(JAWS)$(DIR)MTOGAP:C:SP")
+	field(INPB, "$(P)$(JAWS)$(DIR)MTOGAP:A:SP CP")
+	field(INPC, "$(P)$(JAWS)$(DIR)MTOGAP:B:SP CP")
+	field(INPD, "$(P)$(JAWS)$(DIR)MTOGAP:C:SP CP")
     field(CALC,"B*A*A+C*A+D")
 	info(INTEREST, "MEDIUM")
 }

--- a/enginxJawsApp/Db/enginxjawset.template
+++ b/enginxJawsApp/Db/enginxjawset.template
@@ -1,0 +1,51 @@
+# Coupled Slit soft motor record (half a jaw)
+#
+#  Macros:
+#    P - base name for ioc
+#	 DIR - the axis direction
+#    MTR - the IOC postfix of the motor that is being used to drive the slits
+#    HIGH_GAP_LIMIT highest gap value that can be set
+#    LOW_GAP_LIMIT lowest gap value that can be set
+#	 MTR_TO_GAP the equation to change the motor reading to a gap
+#	 MTR_FROM_GAP the equation to change the gap to the motor set point
+
+record(motor,"$(P)$(JAWS)$(DIR)GAP") 
+{ 
+	field(DESC, "$(dir_name) gap on the jaws")
+    field(DTYP,"Soft Channel") 
+    field(OUT,"$(P)$(JAWS)$(DIR)MFRMGAP.A  PP MS") 
+    field(RDBL,"$(P)$(JAWS)$(DIR)MTOGAP.VAL  NPP MS") 
+    field(URIP,"Yes") 
+    field(STOO,"$(P)$(MTR).STOP  PP MS") 
+    field(DINP,"$(P)$(MTR).DMOV  NPP MS") 
+    field(MRES,"1.000") 
+    field(RRES,"1.000")
+    field(PREC,"3") 
+    field(DHLM,"$(HIGH_GAP_LIMIT)") 
+    field(DLLM,"$(LOW_GAP_LIMIT)") 
+    field(TWV,"5") 
+	field(RDBD,"1")
+    field(RTRY,"0") 
+    field(EGU,"mm") 
+    info(INTEREST, "HIGH")
+    info(archive,"0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV")
+	info(alarm,"Motors")
+}
+
+alias("$(P)$(JAWS)$(DIR)GAP", "$(P)$(JAWS)$(DIR)GAP:SP")
+alias("$(P)$(JAWS)$(DIR)GAP", "$(P)$(JAWS)$(DIR)GAP:SP:RBV")
+
+
+record(calcout, "$(P)$(JAWS)$(DIR)MFRMGAP") 
+{ 
+	field(DESC,"Convert gap distance to steps") 
+    field(CALC,"$(MTR_FROM_GAP)") 	
+    field(OUT,"$(P)$(MTR).DVAL  PP MS")
+}
+
+record(calcout,"$(P)$(JAWS)$(DIR)MTOGAP") 
+{
+    field(DESC,"Convert steps to gap distance")
+    field(INPA,"$(P)$(MTR).DRBV  CP MS")
+    field(CALC,"$(MTR_TO_GAP)") 
+}

--- a/enginxJawsApp/Makefile
+++ b/enginxJawsApp/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/enginxJawsApp/src/Makefile
+++ b/enginxJawsApp/src/Makefile
@@ -1,0 +1,8 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2400

To test:
- [ ] The settings in the jaws component within the ENGINX branch match those of the VI
- [ ] The logic in enginxjawset.db matches that in the VI
- [ ] The jaws.cmd in the ENGINX branch correctly creates the three jaw sets
- [ ] You can connect with and manipulate jaw sets 1 & 2 with the standard jaws opi
- [ ] You can connect with and manipulate jaw set 3 with the enginx jaws OPI
- [ ] You can modify the calibration of the 3rd jaw set, this is autosaved
- [ ] The limits etc. outlined in https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/EnginX-Jaws match those in the VI
