### PR TITLE
Add Gem jaws manager/overview screen

### DIFF
--- a/gemJawsApp/Db/Makefile
+++ b/gemJawsApp/Db/Makefile
@@ -1,0 +1,23 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+DB += gemjawset.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/gemJawsApp/Db/gemjawset.db
+++ b/gemJawsApp/Db/gemjawset.db
@@ -1,0 +1,123 @@
+# Gem jaw set Soft motor record
+#
+# Calculates positions for jaw sets
+#
+# Macros:
+#    P - base name for ioc
+#    J1_SCALE - the scale factor for jaws 1 (0.627 on old jaws)
+#    J2_SCALE - the scale factor for jaws 2 (0.521 on old jaws)
+#    J3_SCALE - the scale factor for jaws 3 (0.396 on old jaws)
+#    J4_SCALE - the scale factor for jaws 4 (0.2545 on old jaws)
+#    J5_SCALE - the scale factor for jaws 5 (0.097 on old jaws)
+#
+# In each case, scale is a multiplier for an expression of the form:
+#    setpoint = sample_height + (mod_height-sample_height) * scale
+# And an analogous formula for width.
+#
+
+
+record(ai, "$(P)GEMJAWSET:SAMPLE:HGAP:SP") {
+  field(DESC, "Set width at the sample")
+  field(PREC, "2")
+  field(FLNK, "$(P)GEMJAWSET:HGAP:_FAN")
+  field(EGU, "")
+  info(archive, "VAL")
+}
+
+record(ai, "$(P)GEMJAWSET:SAMPLE:VGAP:SP") {
+  field(DESC, "Set height at the sample")
+  field(PREC, "2")
+  field(FLNK, "$(P)GEMJAWSET:VGAP:_FAN")
+  field(EGU, "")
+  info(archive, "VAL")
+}
+
+record(ai, "$(P)GEMJAWSET:MOD:HGAP:SP") {
+  field(DESC, "Set width at the moderator")
+  field(PREC, "2")
+  field(FLNK, "$(P)GEMJAWSET:HGAP:_FAN")
+  field(EGU, "")
+  info(archive, "VAL")
+}
+
+record(ai, "$(P)GEMJAWSET:MOD:VGAP:SP") {
+  field(DESC, "Set height at the moderator")
+  field(PREC, "2")
+  field(FLNK, "$(P)GEMJAWSET:VGAP:_FAN")
+  field(EGU, "")
+  info(archive, "VAL")
+}
+
+record(transform, "$(P)GEMJAWSET:HGAP:_FAN") {
+
+  field(INPA, "$(P)GEMJAWSET:SAMPLE:HGAP:SP")
+  field(INPB, "$(P)GEMJAWSET:MOD:HGAP:SP")
+  
+  field(CLCC, "A+(B-A)*$(J1_SCALE)") 
+  field(CLCD, "A+(B-A)*$(J2_SCALE)") 
+  field(CLCE, "A+(B-A)*$(J3_SCALE)") 
+  field(CLCF, "A+(B-A)*$(J4_SCALE)") 
+  field(CLCG, "A+(B-A)*$(J5_SCALE)") 
+  
+  field(OUTC, "$(P)MOT:JAWS1:HGAP:SP PP")
+  field(OUTD, "$(P)MOT:JAWS2:HGAP:SP PP")
+  field(OUTE, "$(P)MOT:JAWS3:HGAP:SP PP")
+  field(OUTF, "$(P)MOT:JAWS4:HGAP:SP PP")
+  field(OUTG, "$(P)MOT:JAWS5:HGAP:SP PP")
+  
+}
+
+record(transform, "$(P)GEMJAWSET:VGAP:_FAN") {
+
+  field(INPA, "$(P)GEMJAWSET:SAMPLE:VGAP:SP")
+  field(INPB, "$(P)GEMJAWSET:MOD:VGAP:SP")
+  
+  field(CLCC, "A+(B-A)*$(J1_SCALE)") 
+  field(CLCD, "A+(B-A)*$(J2_SCALE)") 
+  field(CLCE, "A+(B-A)*$(J3_SCALE)") 
+  field(CLCF, "A+(B-A)*$(J4_SCALE)") 
+  field(CLCG, "A+(B-A)*$(J5_SCALE)") 
+  
+  field(OUTC, "$(P)MOT:JAWS1:VGAP:SP PP")
+  field(OUTD, "$(P)MOT:JAWS2:VGAP:SP PP")
+  field(OUTE, "$(P)MOT:JAWS3:VGAP:SP PP")
+  field(OUTF, "$(P)MOT:JAWS4:VGAP:SP PP")
+  field(OUTG, "$(P)MOT:JAWS5:VGAP:SP PP")
+  
+}
+
+record(ao, "$(P)GEMJAWSET:VCENT:SP") {
+  field(DESC, "Global Vertical Setpoint")
+  field(FLNK, "$(P)GEMJAWSET:VCENT:_FAN")
+  field(PREC, "2")
+  field(EGU, "")
+}
+
+record(ao, "$(P)GEMJAWSET:HCENT:SP") {
+  field(DESC, "Global Horizontal Setpoint")
+  field(FLNK, "$(P)GEMJAWSET:HCENT:_FAN")
+  field(PREC, "2")
+  field(EGU, "")  
+}
+
+record(dfanout,"$(P)GEMJAWSET:VCENT:_FAN") {
+  field(DOL, "$(P)GEMJAWSET:VCENT:SP PP")
+  field(OMSL, "closed_loop")
+ 
+  field(OUTA, "$(P)MOT:JAWS1:VCENT:SP PP")
+  field(OUTB, "$(P)MOT:JAWS2:VCENT:SP PP")
+  field(OUTC, "$(P)MOT:JAWS3:VCENT:SP PP")
+  field(OUTD, "$(P)MOT:JAWS4:VCENT:SP PP")
+  field(OUTE, "$(P)MOT:JAWS5:VCENT:SP PP")
+}
+
+record(dfanout,"$(P)GEMJAWSET:HCENT:_FAN") {
+  field(DOL, "$(P)GEMJAWSET:HCENT:SP PP")
+  field(OMSL, "closed_loop")
+    
+  field(OUTA, "$(P)MOT:JAWS1:HCENT:SP PP")
+  field(OUTB, "$(P)MOT:JAWS2:HCENT:SP PP")
+  field(OUTC, "$(P)MOT:JAWS3:HCENT:SP PP")
+  field(OUTD, "$(P)MOT:JAWS4:HCENT:SP PP")
+  field(OUTE, "$(P)MOT:JAWS5:HCENT:SP PP")
+}

--- a/gemJawsApp/Makefile
+++ b/gemJawsApp/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/settings/gem_jaws/jaws.cmd
+++ b/settings/gem_jaws/jaws.cmd
@@ -1,0 +1,13 @@
+############ Gem jaws ##############
+# Create a soft motor record on top of a normal motor record which allow the gap to be set for the motor
+# Copy this file to C:\Instrument\Settings\config\<machine>\configurations\galil
+
+$(IFIOC_GALIL_01) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0104,mXS=MTR0103,mXW=MTR0102,mXE=MTR0101")
+$(IFIOC_GALIL_01) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS2:,mXN=MTR0108,mXS=MTR0107,mXW=MTR0106,mXE=MTR0105")
+$(IFIOC_GALIL_02) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS3:,mXN=MTR0204,mXS=MTR0203,mXW=MTR0202,mXE=MTR0201")
+$(IFIOC_GALIL_02) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS4:,mXN=MTR0208,mXS=MTR0207,mXW=MTR0206,mXE=MTR0205")
+$(IFIOC_GALIL_03) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS5:,mXN=MTR0301,mXS=MTR0303,mXW=MTR0304,mXE=MTR0302")
+
+# Define jaws as soft motor records using the second galil controller, if present
+
+$(IFIOC_GALIL_01) dbLoadRecords("C:/Instrument/Apps/EPICS/support/motorExtensions/master/db/gemjawset.db", "P=$(MYPVPREFIX),J1_SCALE=0.627,J2_SCALE=0.521,J3_SCALE=0.396,J4_SCALE=0.2545,J5_SCALE=0.097")


### PR DESCRIPTION
DB file for the GEM jaw set, https://github.com/ISISComputingGroup/IBEX/issues/2859

Using the calculations as per the labview in `C:\LabVIEW Modules\Instruments\GEM\GEM Beamline Jaws`

To set up:

Use a `jaws.cmd` in `configurations/galil` with the following contents:

```
############ Gem jaws ##############
# Create a soft motor record on top of a normal motor record which allow the gap to be set for the motor
# Copy this file to C:\Instrument\Settings\config\<machine>\configurations\galil

$(IFIOC_GALIL_01) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS1:,mXN=MTR0104,mXS=MTR0103,mXW=MTR0102,mXE=MTR0101")
$(IFIOC_GALIL_01) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS2:,mXN=MTR0108,mXS=MTR0107,mXW=MTR0106,mXE=MTR0105")
$(IFIOC_GALIL_02) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS3:,mXN=MTR0204,mXS=MTR0203,mXW=MTR0202,mXE=MTR0201")
$(IFIOC_GALIL_02) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS4:,mXN=MTR0208,mXS=MTR0207,mXW=MTR0206,mXE=MTR0205")
$(IFIOC_GALIL_03) dbLoadRecords("$(JAWS)/db/jaws.db","P=$(MYPVPREFIX)MOT:,JAWS=JAWS5:,mXN=MTR0301,mXS=MTR0303,mXW=MTR0304,mXE=MTR0302")

# Define jaws as soft motor records using the second galil controller, if present

$(IFIOC_GALIL_01) dbLoadRecords("C:/Instrument/Apps/EPICS/support/motorExtensions/master/db/gemjawset.db", "P=$(MYPVPREFIX),J1_SCALE=0.627,J2_SCALE=0.521,J3_SCALE=0.396,J4_SCALE=0.2545,J5_SCALE=0.097")

```

I've added a note to the commissioning ticket https://github.com/ISISComputingGroup/IBEX/issues/2858 to check these distances and adjust them if they've been changed.