### PR TITLE
Ticket 2138: Fixed beamscraper jaws tests

### DIFF
--- a/settings/motorExtensions.cmd
+++ b/settings/motorExtensions.cmd
@@ -11,4 +11,4 @@ $(IFTESTDEVSIM) $(IFOSCCOL=#) < $(MOTOREXT)/settings/oscillatingCollimator/oscil
 $(IFNOTTESTDEVSIM) < $(GALILCONFIG)/emma_chopper_lifter.cmd
 $(IFTESTDEVSIM) $(IFCHOPLIFT=#) < $(MOTOREXT)/settings/emma_chopper_lifter/emma_chopper_lifter.cmd
 
-$(IFTESTDEVSIM) $(IFGEMJAWS=#) < $(MOTOREXT)/settings/gem_jaws/jaws.cmd
+$(IFTESTRECSIM) $(IFGEMJAWS=#) < $(MOTOREXT)/settings/gem_jaws/jaws.cmd


### PR DESCRIPTION
Lets the IOC tests added in https://github.com/ISISComputingGroup/IBEX/issues/2138 be run without a jaws.cmd in the settings directory. 