### PR TITLE
Ticket 3120: Fix system tests

### DIFF
--- a/gemBeamscraperJawsApp/Db/linearaxis.template
+++ b/gemBeamscraperJawsApp/Db/linearaxis.template
@@ -89,13 +89,12 @@ record(calcout, "$(P)$(CAL_AXIS):SET:MTR:LO:LIM")
     field(OUT,  "$(P)$(MTR).LLM PP MS")
 }
 
-record(calcout,"$(P)$(CAL_AXIS):READ") 
+record(calc,"$(P)$(CAL_AXIS):READ") 
 {
     field(DESC,"Convert steps to user readback")
 	field(INPB, "$(P)$(CAL_AXIS):READ:B:SP CP")
 	field(INPC, "$(P)$(CAL_AXIS):READ:C:SP CP")
 	field(INPD,"$(P)$(MTR).RBV CP MS")
-	field(OUT, "$(P)$(CAL_AXIS) PP MS")
     field(CALC,"B*D+C")
 	info(INTEREST, "LOW")
 }

--- a/gemBeamscraperJawsApp/Db/quadaxis.template
+++ b/gemBeamscraperJawsApp/Db/quadaxis.template
@@ -97,13 +97,12 @@ record(calcout, "$(P)$(CAL_AXIS):SET:MTR:LO:LIM")
     field(OUT,  "$(P)$(MTR).LLM  PP MS")
 }
 
-record(calcout,"$(P)$(CAL_AXIS):READ") 
+record(calc,"$(P)$(CAL_AXIS):READ") 
 {
     field(DESC, "Convert steps to user readback")
 	field(INPA, "$(P)$(CAL_AXIS):READ:A CP")
 	field(INPB, "$(P)$(CAL_AXIS):READ:B CP")
 	field(INPC, "$(P)$(CAL_AXIS):READ:C CP")
     field(INPD, "$(P)$(MTR).RBV CP MS")
-	field(OUT, "$(P)$(CAL_AXIS) PP MS")
     field(CALC, "A*D*D+B*D+C")
 }


### PR DESCRIPTION
See ticket: https://github.com/ISISComputingGroup/IBEX/issues/3120

This occurred due to the motor readback for the calibrated axis being set in both the RDBL field and the CAL:READ record. This caused the the calibrated axis to push a value back to the underlying motor. It only became an issue when the MRES was lowered.

To test:
* Run the ioc system test

## Acceptance criteria

- [ ] If you have updated the `settings` directory, have you added a corresponding step to the upgrade script to update affected instruments?
