### PR TITLE
Ticket3623 loq aperture

### DIFF
--- a/loqApertureApp/Db/Makefile
+++ b/loqApertureApp/Db/Makefile
@@ -11,7 +11,7 @@ include $(TOP)/configure/CONFIG
 # Create and install (or just install) into <top>/db
 # databases, templates, substitutions like this
 #DB += xxx.db
-DB += emmaChopperLifter.db
+DB += loqAperture.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/loqApertureApp/Db/Makefile
+++ b/loqApertureApp/Db/Makefile
@@ -1,0 +1,23 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+# Create and install (or just install) into <top>/db
+# databases, templates, substitutions like this
+#DB += xxx.db
+DB += emmaChopperLifter.db
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/loqApertureApp/Db/loqAperture.db
+++ b/loqApertureApp/Db/loqAperture.db
@@ -4,7 +4,7 @@
 record(calc, "$(P)APERTURE:CLOSESTSHUTTER")
 {
     field(DESC, "Returns closest aperture beam stop")
-    field(CALC, "A==0? 1 : (A==2|A==4)? 3 : A ")
+    field(CALC, "A==0? 1 : (A==2 || A==4)? 3 : A ")
     field(INPA, "$(SETPTAXIS)IPOSN CP MS")
 }
 

--- a/loqApertureApp/Db/loqAperture.db
+++ b/loqApertureApp/Db/loqAperture.db
@@ -1,0 +1,17 @@
+# If position index is odd, then current location is shutter
+# If index is even and less than 4 (i.e. 2), closest shutter is current index + 1
+# If index even and greater than or equal to 4 (i.e. 4,6), closest shutter is current index - 1
+record(calc, "$(P)APERTURE:CLOSESTSHUTTER")
+{
+    field(DESC, "Returns closest aperture beam stop")
+    field(CALC, "A%2==1? 0: ( (A<4)? A+1 : A-1)")
+    field(INPA, "$(SETPTAXIS)IPOSN CP MS")
+}
+
+record(dfanout, "$(P)APERTURE:CLOSEAPERTURE")
+{
+    field(DESC, "Sends move instruction to shut aperture")
+    field(OMSL, "closed_loop")
+    field(DOL, "$(P)APERTURE:CLOSESTSHUTTER")
+    field(OUTA, "$(SETPTAXIS)IPOSN:SP PP")
+}

--- a/loqApertureApp/Db/loqAperture.db
+++ b/loqApertureApp/Db/loqAperture.db
@@ -1,10 +1,10 @@
-# If position index is odd, then current location is shutter
-# If index is even and less than 4 (i.e. 2), closest shutter is current index + 1
-# If index even and greater than or equal to 4 (i.e. 4,6), closest shutter is current index - 1
+# Move to pos 3 (beamstop) from medium and small apertures (pos 2,3).
+# Move to pos 1 (beamstop) from large aperture (pos 1).
+# Stay on current position if already on stop. Defined in ticket 3623.
 record(calc, "$(P)APERTURE:CLOSESTSHUTTER")
 {
     field(DESC, "Returns closest aperture beam stop")
-    field(CALC, "A%2==0? A: ( (A<4)? A+1 : A-1)")
+    field(CALC, "A==0? 1 : (A==2|A==4)? 3 : A ")
     field(INPA, "$(SETPTAXIS)IPOSN CP MS")
 }
 

--- a/loqApertureApp/Db/loqAperture.db
+++ b/loqApertureApp/Db/loqAperture.db
@@ -4,7 +4,7 @@
 record(calc, "$(P)APERTURE:CLOSESTSHUTTER")
 {
     field(DESC, "Returns closest aperture beam stop")
-    field(CALC, "A%2==1? 0: ( (A<4)? A+1 : A-1)")
+    field(CALC, "A%2==0? A: ( (A<4)? A+1 : A-1)")
     field(INPA, "$(SETPTAXIS)IPOSN CP MS")
 }
 

--- a/loqApertureApp/Makefile
+++ b/loqApertureApp/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+include $(TOP)/configure/RULES_DIRS
+

--- a/loqApertureApp/src/Makefile
+++ b/loqApertureApp/src/Makefile
@@ -1,0 +1,8 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/settings/gem_jaws/motorExtensions.cmd
+++ b/settings/gem_jaws/motorExtensions.cmd
@@ -1,0 +1,5 @@
+############ Motor Extensions ##############
+# Create a soft motor record on top of a normal motor record which allow the gap to be set for the motor
+# Copy this file to C:\Instrument\Settings\config\<machine>\configurations\galil
+
+$(IFTESTRECSIM) $(IFGEMJAWS=#) < $(MOTOREXT)/settings/gem_jaws/jaws.cmd

--- a/settings/loqAperture/axes.cmd
+++ b/settings/loqAperture/axes.cmd
@@ -1,0 +1,1 @@
+$(IFIOC_GALIL_01) dbLoadRecords("$(AXIS)/db/axis.db","P=$(MYPVPREFIX)MOT:,AXIS=APERTURE,mAXIS=MTR0101")

--- a/settings/loqAperture/motionSetPoints/aperture.txt
+++ b/settings/loqAperture/motionSetPoints/aperture.txt
@@ -1,0 +1,6 @@
+# Convert sample position names to motor coordinates
+Aperture_large   02.900000
+Stop_01          15.400000
+Aperture_medium  27.900000
+Stop_02          40.400000
+Aperture_small   52.900000

--- a/settings/loqAperture/motionsetpoints.cmd
+++ b/settings/loqAperture/motionsetpoints.cmd
@@ -1,0 +1,9 @@
+epicsEnvSet "LOOKUPFILE1" "$(ICPCONFIGROOT)/motionSetPoints/aperture.txt"
+
+motionSetPointsConfigure("LOOKUPFILE1","LOOKUPFILE1")
+
+# The tolerance must be large to make sure that LOCN always points to the closest setpoint
+$(IFIOC_GALIL_01) dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db","P=$(MYPVPREFIX)LKUP:APERTURE:,NAME1=APERTURE,AXIS1=$(MYPVPREFIX)MOT:APERTURE,TOL=10,LOOKUP=LOOKUPFILE1")
+
+# Load the records which control closing the aperture
+$(IFIOC_GALIL_01) dbLoadRecords("$(MOTOREXT)/db/loqAperture.db", "P=$(MYPVPREFIX), SETPTAXIS=$(MYPVPREFIX)LKUP:APERTURE:")

--- a/settings/motorExtensions.cmd
+++ b/settings/motorExtensions.cmd
@@ -2,13 +2,4 @@
 # Create a soft motor record on top of a normal motor record which allow the gap to be set for the motor
 # Copy this file to C:\Instrument\Settings\config\<machine>\configurations\galil
 
-$(IFNOTTESTDEVSIM) < $(GALILCONFIG)/xyBeamstop.cmd
-$(IFTESTDEVSIM) $(IFXYBEAMSTOP=#) < $(MOTOREXT)/settings/xyBeamstop/xyBeamstop.cmd
-
-$(IFNOTTESTDEVSIM) < $(GALILCONFIG)/oscillatingCollimator.cmd
-$(IFTESTDEVSIM) $(IFOSCCOL=#) < $(MOTOREXT)/settings/oscillatingCollimator/oscillatingCollimator.cmd
-
-$(IFNOTTESTDEVSIM) < $(GALILCONFIG)/emma_chopper_lifter.cmd
-$(IFTESTDEVSIM) $(IFCHOPLIFT=#) < $(MOTOREXT)/settings/emma_chopper_lifter/emma_chopper_lifter.cmd
-
 $(IFTESTRECSIM) $(IFGEMJAWS=#) < $(MOTOREXT)/settings/gem_jaws/jaws.cmd

--- a/settings/xyBeamstop/motorExtensions.cmd
+++ b/settings/xyBeamstop/motorExtensions.cmd
@@ -1,0 +1,5 @@
+############ Motor Extensions ##############
+# Create a soft motor record on top of a normal motor record which allow the gap to be set for the motor
+# Copy this file to C:\Instrument\Settings\config\<machine>\configurations\galil
+
+< $(GALILCONFIG)/xyBeamstop.cmd


### PR DESCRIPTION
Adds a LOQ aperture extension which selects the closest beamstop on the aperture plate to move to when a 'shutter' is requested.

Also moved some of the boot logic to each motor extension's settings directory, so these now act as minimum viable directories to get the motor extensions to boot. This removes the need for extra lines in the boot file when working in simulated modes.

## Acceptance criteria

- [x] LOQ aperture can be closed by processing a PV.

- [x] When requested, the aperture closes to the nearest beamstop, as defined in the [Ticket](https://github.com/ISISComputingGroup/IBEX/issues/3623)

- [ ] If you have updated the `settings` directory, have you added a corresponding step to the upgrade script to update affected instruments?
