### PR TITLE
Point to the nearest setpoint rather than making tolerances large

### DIFF
--- a/loqApertureApp/Db/loqAperture.db
+++ b/loqApertureApp/Db/loqAperture.db
@@ -8,10 +8,10 @@ record(calc, "$(P)APERTURE:CLOSESTSHUTTER")
     field(INPA, "$(SETPTAXIS)NIPOSN CP MS")
 }
 
-record(dfanout, "$(P)APERTURE:CLOSEAPERTURE")
+record(longout, "$(P)APERTURE:CLOSEAPERTURE")
 {
     field(DESC, "Sends move instruction to shut aperture")
     field(OMSL, "closed_loop")
     field(DOL, "$(P)APERTURE:CLOSESTSHUTTER")
-    field(OUTA, "$(SETPTAXIS)IPOSN:SP PP")
+    field(OUT, "$(SETPTAXIS)IPOSN:SP PP")
 }

--- a/loqApertureApp/Db/loqAperture.db
+++ b/loqApertureApp/Db/loqAperture.db
@@ -5,7 +5,7 @@ record(calc, "$(P)APERTURE:CLOSESTSHUTTER")
 {
     field(DESC, "Returns closest aperture beam stop")
     field(CALC, "A==0? 1 : (A==2 || A==4)? 3 : A ")
-    field(INPA, "$(SETPTAXIS)IPOSN CP MS")
+    field(INPA, "$(SETPTAXIS)NIPOSN CP MS")
 }
 
 record(dfanout, "$(P)APERTURE:CLOSEAPERTURE")

--- a/settings/loqAperture/motionsetpoints.cmd
+++ b/settings/loqAperture/motionsetpoints.cmd
@@ -2,8 +2,7 @@ epicsEnvSet "LOOKUPFILE1" "$(ICPCONFIGROOT)/motionSetPoints/aperture.txt"
 
 motionSetPointsConfigure("LOOKUPFILE1","LOOKUPFILE1")
 
-# The tolerance must be large to make sure that LOCN always points to the closest setpoint
-$(IFIOC_GALIL_01) dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db","P=$(MYPVPREFIX)LKUP:APERTURE:,NAME1=APERTURE,AXIS1=$(MYPVPREFIX)MOT:APERTURE,TOL=10,LOOKUP=LOOKUPFILE1")
+$(IFIOC_GALIL_01) dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db","P=$(MYPVPREFIX)LKUP:APERTURE:,NAME1=APERTURE,AXIS1=$(MYPVPREFIX)MOT:APERTURE,LOOKUP=LOOKUPFILE1")
 
 # Load the records which control closing the aperture
 $(IFIOC_GALIL_01) dbLoadRecords("$(MOTOREXT)/db/loqAperture.db", "P=$(MYPVPREFIX), SETPTAXIS=$(MYPVPREFIX)LKUP:APERTURE:")


### PR DESCRIPTION
## To test
https://github.com/ISISComputingGroup/IBEX/issues/3962

## Acceptance criteria

- [x] LOQ aperture now points to the nearest set point rather than getting the same information by increasing the tolerances of each set point.

- [ ] If you have updated the `settings` directory, have you added a corresponding step to the upgrade script to update affected instruments?
