### PR TITLE
remove set initial delayed move

### DIFF
--- a/sans2dVacTankApp/Db/sans2d_delayed_move.template
+++ b/sans2dVacTankApp/Db/sans2d_delayed_move.template
@@ -10,15 +10,6 @@ record(dfanout, "$(FULL_PREFIX)SET_DELAYED_MOVE") {
 	field(OUTF, "$(P)FRONTDETX:MTR.SPMG PP")
 	field(OUTG, "$(P)FRONTDETROT:MTR.SPMG PP")
 	field(OUTH, "$(P)REARDETX:MTR.SPMG PP")
-	field(FLNK, "$(FULL_PREFIX)SET_DELAYED_MOVE_EXT")
-}
-
-record(dfanout, "$(FULL_PREFIX)SET_DELAYED_MOVE_EXT") {
-	field(VAL, "1")
-	field(OUTA, "$(P)BEAMSTOP1Y:MTR.SPMG PP")
-	field(OUTB, "$(P)BEAMSTOP2Y:MTR.SPMG PP")
-	field(OUTC, "$(P)BEAMSTOP3Y:MTR.SPMG PP")
-	field(OUTD, "$(P)BEAMSTOPX:MTR.SPMG PP")
 }
 
 record(calcout, "$(FULL_PREFIX)CAN_MOVE_CALC_FDFB") {


### PR DESCRIPTION
SANS2D did not want SPMG control on its beamstops. Sadly this behaviour persists even after the previous flash review, as I missed the part right at the top of the file where all motors are initialised in pause state after the IOC restarts. This PR fixes this.